### PR TITLE
Feature/update readme android

### DIFF
--- a/desenv-app-android/README.md
+++ b/desenv-app-android/README.md
@@ -1,2 +1,15 @@
 [Ir para o quadro de atividades](https://github.com/ops-org/projeto-novo-eleitor/projects/10)
-# Instruções
+
+# Sobre o projeto android
+
+O mesmo encontra-se em um repositório pertencente ao projeto novo eleitor:
+https://github.com/ops-org/projeto-novo-eleitor-ionic
+
+No intuito de desenvolver um MVP (Mínimo Produto Viável) estamos utilizando um framework Híbrido para desenvolvimento, ou seja, que pode ser executado tanto na plataforma iOS quanto Android. A escolha de um projeto em separado se dá pelos seguintes pontos:
+
+* Reduzir o acoplamento da interface;
+* Instalar um servidor de build continuo que ficará monitorando o repositório;
+* Possuir um sistema de issues próprios e wiki para colaboradores;
+
+O projeto Novo Eleitor é uma iniciativa voluntária dos membros da OPS. Junte-se á nós!
+

--- a/desenv-app-ios/README.md
+++ b/desenv-app-ios/README.md
@@ -1,2 +1,15 @@
 [Ir para o quadro de atividades](https://github.com/ops-org/projeto-novo-eleitor/projects/11)
-# Instruções
+
+# Sobre o projeto iOS
+
+O mesmo encontra-se em um repositório pertencente ao projeto novo eleitor:
+https://github.com/ops-org/projeto-novo-eleitor-ionic
+
+No intuito de desenvolver um MVP (Mínimo Produto Viável) estamos utilizando um framework Híbrido para desenvolvimento, ou seja, que pode ser executado tanto na plataforma iOS quanto Android. A escolha de um projeto em separado se dá pelos seguintes pontos:
+
+* Reduzir o acoplamento da interface;
+* Instalar um servidor de build continuo que ficará monitorando o repositório;
+* Possuir um sistema de issues próprios e wiki para colaboradores;
+
+O projeto Novo Eleitor é uma iniciativa voluntária dos membros da OPS. Junte-se á nós!
+


### PR DESCRIPTION
Criado arquivos de ajuda redirecionando para o projeto Android.

Achei melhor realizar essa abordagem uma vez que este projeto já possui várias informações pertinentes à um overview maior sobre a ferramenta (como materiais extras e conceitos) e que não é necessário baixar todos os projetos para que seja desenvolvido a solução android/iOS. Além do quê quero configurar o TravisCI para realizar builds do sistema de modo a garantir que o código que irá subir não quebre o restante do desenvolvimento. 

Gostaria que vocês opinassem e, caso aprovado, favor realizar o merge.

Obrigado